### PR TITLE
Fix storybook failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "test:coverage": "yarn test --coverage",
     "test:watch": "jest --watch",
     "format": "yarn lint:js --fix && yarn lint:ts --fix",
-    "storybook": "start-storybook",
-    "storybook:build": "build-storybook -c .storybook -o .out"
+    "storybook": "gatsby build && start-storybook",
+    "storybook:build": "gatsby build && build-storybook -c .storybook -o .out"
   },
   "dependencies": {
     "@emotion/babel-preset-css-prop": "^10.0.27",


### PR DESCRIPTION
# Fix for #121 

Storybook fails right after a fresh installation because gatsby has never been build yet.

We can ensure a proper fresh Gatsby build to be available by running `gatsby build` right before invoking any `storybook` command.